### PR TITLE
feat: add view count display to podcast detail and profile pages

### DIFF
--- a/app/(root)/podcasts/[podcastId]/page.tsx
+++ b/app/(root)/podcasts/[podcastId]/page.tsx
@@ -7,9 +7,9 @@ import PodcastPlayerDetails from '@/components/PodcastPlayerDetails'
 import { api } from '@/convex/_generated/api'
 import { Id } from '@/convex/_generated/dataModel'
 import { useUser } from '@clerk/nextjs'
-import { useQuery } from 'convex/react'
+import { useMutation, useQuery } from 'convex/react'
 import Image from 'next/image'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 const PodcastDetails = ({ params: { podcastId } }: { params: { podcastId: Id<'podcasts'> } }) => {
 
@@ -18,8 +18,15 @@ const PodcastDetails = ({ params: { podcastId } }: { params: { podcastId: Id<'po
   const podcast = useQuery(api.podcasts.getPodcastById, { podcastId })
 
   const similarPodcasts = useQuery(api.podcasts.getPodcastByVoiceType, { podcastId });
+  const updateViews = useMutation(api.podcasts.updatePodcastViews);
 
   const isOwner = user?.id === podcast?.authorId;
+
+  useEffect(() => {
+    if (podcast) {
+      updateViews({ podcastId });
+    }
+  }, [podcastId]);
 
   if (!similarPodcasts || !podcast) return <LoaderSpinner />
 

--- a/components/PodcastPlayerDetails.tsx
+++ b/components/PodcastPlayerDetails.tsx
@@ -45,6 +45,7 @@ const PodcastDetailPlayer = ({
   authorImageURL,
   authorId,
   _creationTime,
+  views,
 }: PodcastDetailPlayerProps) => {
   const router = useRouter();
   const { setAudio } = useAudio();
@@ -118,6 +119,8 @@ const PodcastDetailPlayer = ({
             <span>{getRelativeTime(_creationTime)}</span>
             <span>•</span>
             <span>Episode</span>
+            <span>•</span>
+            <span>{views.toLocaleString()} {views === 1 ? 'view' : 'views'}</span>
           </div>
 
           {/* Title */}

--- a/components/ProfileCard.tsx
+++ b/components/ProfileCard.tsx
@@ -59,6 +59,8 @@ const ProfileCard = ({
           <span className="text-[14px]">Channel</span>
           <span className="text-[14px]">•</span>
           <span className="text-[14px]">{podcastData?.podcasts.length || 0} Shows</span>
+          <span className="text-[14px]">•</span>
+          <span className="text-[14px]">{podcastData?.listeners?.toLocaleString() || 0} Listeners</span>
         </div>
       </div>
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -89,6 +89,7 @@ export interface PodcastDetailPlayerProps {
   authorImageURL: string;
   authorId: string;
   _creationTime: number;
+  views: number;
 }
 
 export interface AudioProps {


### PR DESCRIPTION
Wire up the existing updatePodcastViews mutation to increment views when
a podcast detail page is visited. Display the view count in the podcast
detail header and show total listeners on the profile page.

Closes #2

https://claude.ai/code/session_012fgvZk7GaK4e7QvgMpsEY9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Podcast views are now automatically tracked when visiting a podcast page
* View counts are displayed on podcast player details with locale formatting
* Listener statistics are now shown on podcast profile cards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->